### PR TITLE
支持vue-router /*.html的特殊路由的本地开发

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -72,6 +72,9 @@ app.use(devMiddleware);
 // 使用热更新， 如果编译出现错误会实时展示编译错误
 app.use(hotMiddleware);
 
+// 匹配vue-router类似/*.html这种特殊形式的路由
+app.use('*/*.html', devMiddleware)
+
 // 纯静态资源服务
 let staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory);
 app.use(staticPath, express.static('./static'));


### PR DESCRIPTION
在vue-cli内,本地开发支持类似/*.html这种特殊形式的路由,而目前lavas内vue-router定义这种路由则会出现404.
进一步,为啥会有这种特殊形式的路由,,肯定是为了适应旧项目的路由啦,,有些时候不方便抛弃原先的路由规则.